### PR TITLE
Update update_partitions_no_unknown_table.sql

### DIFF
--- a/update_partitions_no_unknown_table.sql
+++ b/update_partitions_no_unknown_table.sql
@@ -126,7 +126,7 @@ createTrigger:=createTrigger || '
             RAISE EXCEPTION ''Error en trigger'';
             RETURN NULL;
     END;
-    RETURN NEW;
+    RETURN NULL;
     END;
     $$
     LANGUAGE plpgsql;';


### PR DESCRIPTION
On insert, after insertion on the child table, return _NULL_ instead of _NEW_. Otherwise it will duplicate data on childs and parent.
