### PR TITLE
Update update_partitions_no_unknown_table.sql 

### DIFF
--- a/update_partitions_no_unknown_table.sql
+++ b/update_partitions_no_unknown_table.sql
@@ -1,78 +1,88 @@
 --
 -- Update_partitions - Takes a begin time, schema name, primary (parent) table name,
---                     table owner, the name of the date column,
+--                     table owner, an expression which returns a date,
 --                     and if we want 'week'ly or 'month'ly partitions.
 --                     The number of created tables is returned.
 --                     ex: SELECT public.create_date_partitions_for_table('2010-02-01','my_schema','my_data','postgres','create_date','week',1,true,true)
 --
 
--- Function: public.create_date_partitions_for_table(timestamp without time zone, text, text, text, text, text, integer, boolean, boolean)
+-- Function: public.create_date_partitions_for_table(timestamp without time zone, regclass, text, interval, boolean, boolean)
 
--- DROP FUNCTION public.create_date_partitions_for_table(timestamp without time zone, text, text, text, text, text, integer, boolean, boolean);
+-- DROP FUNCTION public.create_date_partitions_for_table(timestamp without time zone, regclass, text, interval, boolean, boolean);
 
-CREATE OR REPLACE FUNCTION public.create_date_partitions_for_table(begin_time timestamp without time zone, schema_name text, primary_table_name text, table_owner text, date_column text, plan text, step integer, fill_child_tables boolean, truncate_parent_table boolean)
-  RETURNS integer AS
+CREATE OR REPLACE FUNCTION public.create_date_partitions_for_table(begin_time timestamp without time zone,
+																   primary_table regclass,
+																   date_expression text,
+																   spacing interval,
+																   fill_child_tables boolean,
+																   truncate_parent_table boolean)
+RETURNS integer AS
 $BODY$
-declare startTime timestamp;
-declare endTime timestamp;
-declare intervalTime timestamp;
-declare createStmts text;
-declare insertStmts text;
-declare createTrigger text;
-declare fullTablename text;
-declare triggerName text;
-declare createdTables integer;
-declare dateFormat text;
-declare planInterval interval;
+DECLARE startTime timestamp;
+DECLARE endTime timestamp;
+DECLARE intervalTime timestamp;
+DECLARE createStmts text;
+DECLARE insertStmts text;
+DECLARE createTrigger text;
+DECLARE fullTablename text;
+DECLARE triggerName text;
+DECLARE createdTables integer;
+DECLARE intervalEpoch integer;
+DECLARE dateFormat text;
+DECLARE dateColumnName text;
+DECLARE tableOwner text;
+DECLARE primary_table_name text;
+DECLARE schema_name text;
  
 BEGIN
-dateFormat:=CASE WHEN plan='month' THEN 'YYYYMM'
-                 WHEN plan='week'  THEN 'IYYYIW'
-                 WHEN plan='day'   THEN 'YYYYDDD'
-         WHEN plan='year'  THEN 'YYYY'
-                 ELSE 'error'
-            END;
-IF dateFormat='error' THEN
-  RAISE EXCEPTION 'Plan % no valido (valores validos son month,week,day,year)', plan;
+-- determine if the date_expression is a valid identifier
+dateColumnName := CASE WHEN date_expression ~* '^[a-z0-9_$]+$' THEN date_expression ELSE 'date' END;
+
+-- determine the date format for the given interval
+intervalEpoch := EXTRACT(EPOCH FROM spacing);
+dateFormat := CASE WHEN intervalEpoch < EXTRACT(EPOCH FROM interval '1 day') THEN 'error'
+		   WHEN intervalEpoch < EXTRACT(EPOCH FROM interval '1 week') THEN 'YYYYDDD'
+		   WHEN intervalEpoch < EXTRACT(EPOCH FROM interval '1 month') THEN 'IYYYIW'
+		   WHEN intervalEpoch < EXTRACT(EPOCH FROM interval '1 year') THEN 'YYYYMM'
+		   ELSE 'YYYY'
+	       END;
+IF dateFormat = 'error' THEN
+  RAISE EXCEPTION 'Interval must be greater than 1 day';
 END IF;
+
+-- get the table name, schema and owner
+SELECT c.relname, n.nspname, a.rolname INTO primary_table_name, schema_name, tableOwner
+FROM pg_catalog.pg_class AS c
+JOIN pg_catalog.pg_namespace AS n ON c.relnamespace = n.oid
+JOIN pg_catalog.pg_authid AS a ON c.relowner = a.oid
+WHERE c.oid = primary_table::oid;
+
 -- Store the incoming begin_time, and set the endTime to one month/week/day in the future 
 --     (this allows use of a cronjob at any time during the month/week/day to generate next month/week/day's table)
-startTime:=(date_trunc(plan,begin_time));
-planInterval:=(step||' '||plan)::interval;
-endTime:=(date_trunc(plan,(current_timestamp + planInterval)));
-createdTables:=0;   
-
--- Begin creating the trigger function
-createTrigger:='CREATE OR REPLACE FUNCTION '||schema_name||'.trf_'||primary_table_name||'_insert_trigger_function()
-                RETURNS TRIGGER AS $$
-    declare startTime timestamp;
-    declare intervalTime timestamp;
-    declare fullTablename text;
-    declare insertStatment text;
-    declare createTableStatment text;
-    BEGIN
-    ';
+startTime := to_timestamp(to_char(begin_time, dateFormat), dateFormat);
+endTime := to_timestamp(to_char(now() + spacing, dateFormat), dateFormat);
+createdTables := 0;  
      
-while (startTime <= endTime) loop
+WHILE (startTime <= endTime) LOOP
  
-   fullTablename:=primary_table_name||'_'||to_char(startTime,dateFormat);
-   intervalTime:= startTime + planInterval;
+   fullTablename := primary_table_name||'_'||to_char(startTime, dateFormat);
+   intervalTime := startTime + spacing;
 
    -- The table creation sql statement
-   if not exists(select * from information_schema.tables where table_schema = schema_name AND table_name = fullTablename) then
-     createStmts:='CREATE TABLE '||schema_name||'.'||fullTablename||' (
-              CHECK ('||date_column||' >= '''||startTime||''' AND '||date_column||' < '''||intervalTime||''')
+   IF NOT EXISTS(SELECT * FROM information_schema.tables WHERE table_schema = schema_name AND table_name = fullTablename) THEN
+     createStmts := 'CREATE TABLE '||schema_name||'.'||fullTablename||' (
+              CHECK ('||date_expression||' >= '''||startTime||''' AND '||date_expression||' < '''||intervalTime||''')
               ) INHERITS ('||schema_name||'.'||primary_table_name||')';    
  
      -- Run the table creation
      EXECUTE createStmts;
     
      -- Set the table owner     
-     createStmts :='ALTER TABLE '||schema_name||'.'||fullTablename||' OWNER TO '||table_owner||';';
+     createStmts := 'ALTER TABLE '||schema_name||'.'||fullTablename||' OWNER TO '||tableOwner||';';
      EXECUTE createStmts;     
   
      -- Create an index on the timestamp     
-     createStmts:='CREATE INDEX idx_'||fullTablename||'_'||date_column||' ON '||schema_name||'.'||fullTablename||' ('||date_column||');';
+     createStmts := 'CREATE INDEX idx_'||fullTablename||'_'||dateColumnName||' ON '||schema_name||'.'||fullTablename||' ('||date_expression||');';
      EXECUTE createStmts;
      
      RAISE NOTICE 'Child table %.% created',schema_name,fullTablename;
@@ -80,50 +90,59 @@ while (startTime <= endTime) loop
      --if fill_child_tables is true then we fill the child table with the parent's table data that satisfies the child's table check constraint
      IF (fill_child_tables) THEN
         RAISE NOTICE 'Filling child table %.%',schema_name,fullTablename;
-        insertStmts:='INSERT INTO '||schema_name||'.'||fullTablename||' (
+        insertStmts := 'INSERT INTO '||schema_name||'.'||fullTablename||' (
             SELECT * FROM '||schema_name||'.'||primary_table_name||' 
-            WHERE '||date_column||' >= '''||startTime||''' AND 
-                  '||date_column||' < '''||intervalTime||'''
+            WHERE '||date_expression||' >= '''||startTime||''' AND 
+                  '||date_expression||' < '''||intervalTime||'''
               );';
         EXECUTE insertStmts;
      END IF;
 
      -- Track how many tables we are creating (should likely be 1, except for initial run and backfilling efforts).
-     createdTables:=createdTables+1;
-   end if;
+     createdTables := createdTables+1;
+   END IF;
    
-   startTime:=intervalTime;
+   startTime := intervalTime;
       
-end loop;
--- Finish creating the trigger function
+END LOOP;
+
 -- The UNDEFINED_TABLE exception is captured on child table is created 'on-the-fly' when new data arrives and 
 -- no partition is created to match this data criteria
-createTrigger:=createTrigger || '
-    fullTablename  := '''||primary_table_name||'_''||'||'to_char(NEW.'||date_column||','''||dateFormat||''');
+createTrigger := 'CREATE OR REPLACE FUNCTION '||schema_name||'.trf_'||primary_table_name||'_insert_trigger_function()
+    RETURNS TRIGGER AS $$
+    DECLARE startTime timestamp;
+    DECLARE intervalTime timestamp;
+    DECLARE fullTablename text;
+    DECLARE insertStatment text;
+    DECLARE createTableStatment text;
+	DECLARE formatDate text;
+    BEGIN
+	SELECT to_char('||date_expression||','''||dateFormat||''') INTO formatDate FROM (SELECT NEW.*) AS t;
+    fullTablename  := '''||primary_table_name||'_''||'||'formatDate;
     insertStatment := ''INSERT INTO '||schema_name||'.'''||'||fullTablename||'' VALUES ($1.*)'';
     BEGIN
         --Try insert on appropiatte child table if exists
         EXECUTE insertStatment using NEW;
         --When child tables not exists, generate it on the fly
         EXCEPTION WHEN UNDEFINED_TABLE THEN
-            startTime:=(date_trunc('''||plan||''',NEW.'||date_column||'));
-            intervalTime  := startTime + ('''||step||' '||plan||''')::interval;  
+	    startTime := to_timestamp(formatDate, '''||dateFormat||''');
+            intervalTime  := startTime + '''||spacing||'''::interval;  
 
-            createTableStatment:=''CREATE TABLE '||schema_name||'.''||fullTablename||'' (
-                  CHECK ('||date_column||' >= ''''''||startTime||'''''' AND '||date_column||' < ''''''||intervalTime||'''''')
+            createTableStatment := ''CREATE TABLE '||schema_name||'.''||fullTablename||'' (
+                  CHECK ('||replace(date_expression, '''', '''''')||' >= ''''''||startTime||'''''' AND '||replace(date_expression, '''', '''''')||' < ''''''||intervalTime||'''''')
                   ) INHERITS ('||schema_name||'.'||primary_table_name||')'';    
             EXECUTE createTableStatment;
 
-            createTableStatment :=''ALTER TABLE '||schema_name||'.''||fullTablename||'' OWNER TO '||table_owner||';'';
+            createTableStatment := ''ALTER TABLE '||schema_name||'.''||fullTablename||'' OWNER TO '||tableOwner||';'';
             EXECUTE createTableStatment;
 
-            createTableStatment:=''CREATE INDEX idx_''||fullTablename||''_'||date_column||' ON '||schema_name||'.''||fullTablename||'' ('||date_column||');'';
+            createTableStatment := ''CREATE INDEX idx_''||fullTablename||''_'||dateColumnName||' ON '||schema_name||'.''||fullTablename||'' ('||replace(date_expression, '''', '''''')||');'';
             EXECUTE createTableStatment;    
 
             --Try the insert again, now the table exists
             EXECUTE insertStatment using NEW;
         WHEN OTHERS THEN        
-            RAISE EXCEPTION ''Error en trigger'';
+            RAISE EXCEPTION ''Error in trigger'';
             RETURN NULL;
     END;
     RETURN NULL;
@@ -134,38 +153,34 @@ createTrigger:=createTrigger || '
 EXECUTE createTrigger;
 
 -- Create the trigger that uses the trigger function, if it isn't already created
-triggerName:='tr_'||primary_table_name||'_insert_trigger'; 
-IF NOT EXISTS(select * from information_schema.triggers where trigger_name = triggerName) then
+triggerName := 'tr_'||primary_table_name||'_insert_trigger'; 
+IF NOT EXISTS(SELECT * FROM information_schema.triggers WHERE trigger_name = triggerName) THEN
   createTrigger:='CREATE TRIGGER tr_'||primary_table_name||'_insert_trigger
                   BEFORE INSERT ON '||schema_name||'.'||primary_table_name||' 
                   FOR EACH ROW EXECUTE PROCEDURE '||schema_name||'.trf_'||primary_table_name||'_insert_trigger_function();';
   EXECUTE createTrigger;
 END IF;
 
--- If truncate_parent_table parameter is true, we truncate only the parent table data as this data is in child tables
+-- If truncate_parent_table parameter is true, we truncate only the parent table data AS this data is in child tables
 IF (truncate_parent_table) THEN
     RAISE NOTICE 'Truncate ONLY parent table %.%',schema_name,primary_table_name;
-    insertStmts:='TRUNCATE TABLE ONLY '||schema_name||'.'||primary_table_name||';';
-        EXECUTE insertStmts;
+    insertStmts := 'TRUNCATE TABLE ONLY '||schema_name||'.'||primary_table_name||';';
+    EXECUTE insertStmts;
 END IF;
-
 
 RETURN createdTables;
 END;
 $BODY$
-  LANGUAGE plpgsql VOLATILE
-  COST 100;
-ALTER FUNCTION public.create_date_partitions_for_table(timestamp without time zone, text, text, text, text, text, integer, boolean, boolean)
+LANGUAGE plpgsql VOLATILE
+COST 100;
+ALTER FUNCTION public.create_date_partitions_for_table(timestamp without time zone, regclass, text, interval, boolean, boolean)
   OWNER TO postgres;
-COMMENT ON FUNCTION public.create_date_partitions_for_table(timestamp without time zone, text, text, text, text, text, integer, boolean, boolean) IS 'The function is created in the public schema and is owned by user postgres.
+COMMENT ON FUNCTION public.create_date_partitions_for_table(timestamp without time zone, regclass, text, interval, boolean, boolean) IS 'The function is created in the public schema and is owned by user postgres.
 The function takes params:
 begin_time          - Type: timestamp - Desc: time of your earliest data. This allows for backfilling and for reducing trigger function overhead by avoiding legacy date logic.
-schema_name         - Type: text      - Desc: name of the schema that contains the parent table. Child tables are created here.
-primary_table_name  - Type: text      - Desc: name of the parent table. This is used to generate monthly tables ([primary_table_name]_YYYYMM) and an unknown table ([primary_table_name]_unknowns). It is also used in the trigger and trigger function names.
-table_owner         - Type: text      - Desc: name of PostgreSQL Role to be assigned as owner of the child tables.
-date_column         - Type: text      - Desc: name of the timestamp/date column that is used for check constraints and insert trigger function.
-plan                - Type: text      - Desc: how to implement the partition, valid values are day,week,month,year.
-step                - Type: integer   - Desc: the step taken by the plan (if you want bimestral partition you put plan month and step 2)
+primary_table  		- Type: regclass      - Desc: name of the parent table. This is used to generate monthly tables ([primary_table_name]_YYYYMM) and an unknown table ([primary_table_name]_unknowns). It is also used in the trigger and trigger function names.
+date_expression         - Type: text      - Desc: an expression that returns a date is used for check constraints and insert trigger function.
+spacing                - Type: interval      - Desc: an interval which determines the timespan for child tables
 fill_child_tables   - Type: boolean   - Desc: if you want to load data from parent table to each child tables.
 truncate_parent_table   - Type: boolean   - Desc: if you want to delete table of the parent table
 


### PR DESCRIPTION
Here's my retry for #3. Fixed the bug in the trigger.

Simplified the parameters to do the same thing in 6 parameters that needed 9 parameters before.

The `primary_table` parameter is of type `regclass` and the child tables will use the same schema and table owner as the parent table. The `date` column can now accept an expression which returns a timestamp in addition to a column name. This is necessary to partition on dates derived from hstore or jsonb columns, for example. If the expression contains characters which cannot be included in an identifier, the text `date` is used where the column name was previously used (ie, trigger names).

`plan` and `step` parameters are combined into one parameter, `spacing`, of the `interval` data type. The date format used in child table names is derived from the interval. `1 day` is the minimum granularity supported.

Additionally, as a style preference, I normalized the spacing around assignment operators (`:=`). Made a few other minor formatting changes for consistency.

Similar changes could be made to the `update_partitions.sql`, but I didn't need that file so I only changed this one.
